### PR TITLE
Add "long double" to translations, close #12

### DIFF
--- a/source/dlang_gen.cpp
+++ b/source/dlang_gen.cpp
@@ -1524,7 +1524,7 @@ std::string DlangBindGenerator::_toDBuiltInType(QualType type)
         return "ulong";
     case TY::LongLong:
         return "long";
-    case TY:LongDouble:
+    case TY::LongDouble:
         return "c_long_double";
     default:
         return type.getAsString(*DlangBindGenerator::g_printPolicy);

--- a/source/dlang_gen.cpp
+++ b/source/dlang_gen.cpp
@@ -1524,6 +1524,8 @@ std::string DlangBindGenerator::_toDBuiltInType(QualType type)
         return "ulong";
     case TY::LongLong:
         return "long";
+    case TY:LongDouble:
+        return "c_long_double";
     default:
         return type.getAsString(*DlangBindGenerator::g_printPolicy);
     }


### PR DESCRIPTION
```d
/***
 * Used for a floating point type that corresponds in size and mangling to the associated
 * C++ compiler's `long double` type.
 */
alias c_long_double = real;
```