### PR TITLE
Add ability to develop ohmygentool in a web browser VS Code (using Gitpod, with all dependencies set-up)

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,3 +1,5 @@
+# Test locally with:
+# $ docker build -f .gitpod.Dockerfile -t gitpod-dockerfile-test .
 FROM gitpod/workspace-full
 
 ARG D_VERSION=ldc-1.26.0
@@ -5,7 +7,7 @@ ARG DPATH=/dlang
 
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-RUN apt-get install -y libclang-dev llvm-dev \
+RUN sudo apt-get install -y libclang-dev llvm-dev \
   && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld"
 
 RUN set -ex \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,10 +7,7 @@ ARG DPATH=/dlang
 
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-RUN sudo curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && sudo apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
-    && sudo echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm2.list \
-    && sudo apt-get update \
+RUN sudo apt-get update \
     && sudo apt-get install -y libclang-dev llvm-dev lldb \
     && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,23 @@
+FROM gitpod/workspace-full
+
+ARG D_VERSION=ldc-1.26.0
+ARG DPATH=/dlang
+
+# cmake, lld, clang, clangd, etc already installed
+# See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
+RUN apt-get install -y libclang-dev llvm-dev \
+  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld"
+
+RUN set -ex \
+  && mkdir ${DPATH} \
+  && curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH} \
+  && chmod 755 -R ${DPATH} \
+  && ln -s ${DPATH}/${D_VERSION} ${DPATH}/dc \
+  && ls ${DPATH}
+
+ENV PATH="${DPATH}/${D_VERSION}/bin:${PATH}"
+ENV LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LD_LIBRARY_PATH}"
+
+RUN git clone https://github.com/Tencent/rapidjson.git deps/rapidjson \
+  && cp -r deps/rapidjson/include/rapidjson include

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,7 +7,12 @@ ARG DPATH=/dlang
 
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-RUN sudo apt-get install -y libclang-dev llvm-dev \
+# This installs LLVM 10 
+
+RUN sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+  && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" \
+  && apt-get update \
+  && apt-get install -y libclang-dev llvm-dev lldb \
   && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,7 +9,7 @@ ARG DPATH=/dlang
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
 RUN sudo curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
     && sudo apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
-    && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm2.list \
     && sudo apt-get update \
     && sudo apt-get install -y libclang-dev llvm-dev lldb \
     && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,9 +2,8 @@
 # $ docker build -f .gitpod.Dockerfile -t gitpod-dockerfile-test .
 FROM gitpod/workspace-full
 
-ARG D_VERSION=ldc-1.26.0
-ARG DPATH=/dlang
-
+# Downloads LLVM. The archive is a folder that has "/bin", "/lib", "/include" etc
+# So lets just unpack it into "/usr" and be done
 ARG LLVM_GITHUB_RELEASE_TAG=llvmorg-12.0.1-rc1
 ARG LLVM_GITHUB_RELEASE_FILENAME=clang+llvm-12.0.1-rc1-x86_64-linux-gnu-ubuntu-21.04
 RUN set -ex \
@@ -16,6 +15,14 @@ RUN set -ex \
   && sudo rm -rf ./${LLVM_GITHUB_RELEASE_FILENAME} \
   && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
+# THE ABOVE DOES NOT HAVE WORKING BINARIES
+# BUT: It does correctly configure some CMake nonsense in /usr/lib/cmake/clang, and a bunch of headers + libs
+# We need to now do this, to get working binaries:
+RUN sudo apt-get install clang lld
+
+# Install LDC
+ARG D_VERSION=ldc-1.26.0
+ARG DPATH=/dlang
 RUN set -ex \
   && sudo mkdir ${DPATH} \
   && sudo curl -fsS https://dlang.org/install.sh | sudo bash -s ${D_VERSION} -p ${DPATH} \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,7 +13,7 @@ RUN sudo apt-get update \
 
 RUN set -ex \
   && sudo mkdir ${DPATH} \
-  && sudo curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH} \
+  && sudo curl -fsS https://dlang.org/install.sh | sudo bash -s ${D_VERSION} -p ${DPATH} \
   && sudo chmod 755 -R ${DPATH} \
   && sudo ln -s ${DPATH}/${D_VERSION} ${DPATH}/dc \
   && sudo ls ${DPATH}

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,10 +5,10 @@ FROM gitpod/workspace-full
 ARG D_VERSION=ldc-1.26.0
 ARG DPATH=/dlang
 
-# cmake, lld, clang, clangd, etc already installed
+# cmake, ninja, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-RUN sudo apt-get update \
-    && sudo apt-get install -y libclang-dev llvm-dev lldb \
+# If you run "sudo apt-get update" first, it'll install LLVM 13 tools, but these seem to break somehow
+RUN sudo apt-get install -y libclang-dev llvm-dev lldb \
     && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \
@@ -22,5 +22,8 @@ ENV PATH="${DPATH}/${D_VERSION}/bin:${PATH}"
 ENV LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LIBRARY_PATH}"
 ENV LD_LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LD_LIBRARY_PATH}"
 
-RUN sudo git clone https://github.com/Tencent/rapidjson.git deps/rapidjson \
-  && sudo cp -r deps/rapidjson/include/rapidjson include
+# Not actually an arg, do not change!
+# Just a hacky variable. This is determined by Gitpod and uses the repo name.
+ARG REPO_DIR=/workspace/ohmygentool
+RUN sudo git clone https://github.com/Tencent/rapidjson.git ${REPO_DIR}/deps/rapidjson \
+  && sudo cp -r ${REPO_DIR}/deps/rapidjson/include/rapidjson ${REPO_DIR}/include

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,10 +5,15 @@ FROM gitpod/workspace-full
 ARG D_VERSION=ldc-1.26.0
 ARG DPATH=/dlang
 
-# cmake, ninja, lld, clang, clangd, etc already installed
-# See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-# If you run "sudo apt-get update" first, it'll install LLVM 13 tools, but these seem to break somehow
-RUN sudo apt-get install -y lldb \
+ARG LLVM_GITHUB_RELEASE_TAG=llvmorg-12.0.1-rc1
+ARG LLVM_GITHUB_RELEASE_FILENAME=clang+llvm-12.0.1-rc1-x86_64-linux-gnu-ubuntu-21.04
+RUN set -ex \
+  && sudo apt-get install xz-utils \
+  && sudo wget -O llvm-clang.tar.xz https://github.com/llvm/llvm-project/releases/download/${LLVM_GITHUB_RELEASE_TAG}/${LLVM_GITHUB_RELEASE_FILENAME}.tar.xz \
+  && sudo tar -xvf llvm-clang.tar.xz \
+  && sudo cp -R ./${LLVM_GITHUB_RELEASE_FILENAME}/* /usr \
+  && sudo rm ./llvm-clang.tar.xz \
+  && sudo rm -rf ./${LLVM_GITHUB_RELEASE_FILENAME} \
   && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,8 +8,8 @@ ARG DPATH=/dlang
 # cmake, ninja, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
 # If you run "sudo apt-get update" first, it'll install LLVM 13 tools, but these seem to break somehow
-RUN sudo apt-get install -y libclang-dev llvm-dev lldb \
-    && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
+RUN sudo apt-get install -y lldb \
+  && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \
   && sudo mkdir ${DPATH} \
@@ -21,9 +21,3 @@ RUN set -ex \
 ENV PATH="${DPATH}/${D_VERSION}/bin:${PATH}"
 ENV LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LIBRARY_PATH}"
 ENV LD_LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LD_LIBRARY_PATH}"
-
-# Not actually an arg, do not change!
-# Just a hacky variable. This is determined by Gitpod and uses the repo name.
-ARG REPO_DIR=/workspace/ohmygentool
-RUN sudo git clone https://github.com/Tencent/rapidjson.git ${REPO_DIR}/deps/rapidjson \
-  && sudo cp -r ${REPO_DIR}/deps/rapidjson/include/rapidjson ${REPO_DIR}/include

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,7 +9,7 @@ ARG DPATH=/dlang
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
 RUN sudo curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
     && sudo apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
-    && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm2.list \
+    && sudo echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm2.list \
     && sudo apt-get update \
     && sudo apt-get install -y libclang-dev llvm-dev lldb \
     && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,12 +7,12 @@ ARG DPATH=/dlang
 
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-RUN sudo curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
     && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
     && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
-    && apt-get update \
-    && apt-get install -y libclang-dev llvm-dev lldb \
-    && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
+    && sudo apt-get update \
+    && sudo apt-get install -y libclang-dev llvm-dev lldb \
+    && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \
   && mkdir ${DPATH} \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,13 +7,12 @@ ARG DPATH=/dlang
 
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-# This installs LLVM 10 
-
-RUN sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-  && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" \
-  && apt-get update \
-  && apt-get install -y libclang-dev llvm-dev lldb \
-  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
+RUN sudo curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
+    && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
+    && apt-get update \
+    && apt-get install -y libclang-dev llvm-dev lldb \
+    && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \
   && mkdir ${DPATH} \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,7 +8,7 @@ ARG DPATH=/dlang
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
 RUN sudo apt-get install -y libclang-dev llvm-dev \
-  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld"
+  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \
   && mkdir ${DPATH} \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,23 +7,23 @@ ARG DPATH=/dlang
 
 # cmake, lld, clang, clangd, etc already installed
 # See: https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile
-RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
+RUN sudo curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && sudo apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
     && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
     && sudo apt-get update \
     && sudo apt-get install -y libclang-dev llvm-dev lldb \
     && sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
 
 RUN set -ex \
-  && mkdir ${DPATH} \
-  && curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH} \
-  && chmod 755 -R ${DPATH} \
-  && ln -s ${DPATH}/${D_VERSION} ${DPATH}/dc \
-  && ls ${DPATH}
+  && sudo mkdir ${DPATH} \
+  && sudo curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH} \
+  && sudo chmod 755 -R ${DPATH} \
+  && sudo ln -s ${DPATH}/${D_VERSION} ${DPATH}/dc \
+  && sudo ls ${DPATH}
 
 ENV PATH="${DPATH}/${D_VERSION}/bin:${PATH}"
 ENV LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LIBRARY_PATH}"
 ENV LD_LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LD_LIBRARY_PATH}"
 
-RUN git clone https://github.com/Tencent/rapidjson.git deps/rapidjson \
-  && cp -r deps/rapidjson/include/rapidjson include
+RUN sudo git clone https://github.com/Tencent/rapidjson.git deps/rapidjson \
+  && sudo cp -r deps/rapidjson/include/rapidjson include

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+image:
+  file: .gitpod.Dockerfile

--- a/Dockerfile.local-dev
+++ b/Dockerfile.local-dev
@@ -1,0 +1,81 @@
+
+# Remote development container for VS Code and CLion
+# 
+# Build and run:
+#   docker build -t gentool-devcontainer -f Dockerfile.clion-remote .
+#   docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name gentool-devcontainer
+#   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
+#
+# stop:
+#   docker stop clion_remote_env
+# 
+# ssh credentials (test user):
+#   user@password
+ARG UBUNTU_VERSION=21.10
+
+FROM ubuntu:${UBUNTU_VERSION} AS base_deps
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  tzdata \
+  ssh \
+  git \
+  curl wget \
+  tar zip unzip \
+  rsync \
+  python3 python-is-python3 pip \
+  ninja-build make \
+  libxml2 \
+  && apt-get clean 
+
+# Download prebuilt LLVM from Github, extract to "/usr" directory, set "lld" as default linker
+FROM base_deps AS llvm_deps
+ARG LLVM_GITHUB_RELEASE_TAG=llvmorg-12.0.1-rc1
+ARG LLVM_GITHUB_RELEASE_FILENAME=clang+llvm-12.0.1-rc1-x86_64-linux-gnu-ubuntu-21.04
+RUN set -ex \
+  && apt-get install xz-utils \
+  && wget -O llvm-clang.tar.xz https://github.com/llvm/llvm-project/releases/download/${LLVM_GITHUB_RELEASE_TAG}/${LLVM_GITHUB_RELEASE_FILENAME}.tar.xz \
+  && tar -xvf llvm-clang.tar.xz \
+  && cp -R ./${LLVM_GITHUB_RELEASE_FILENAME}/* /usr \
+  && rm ./llvm-clang.tar.xz \
+  && rm -rf ./${LLVM_GITHUB_RELEASE_FILENAME} \
+  && update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/lld" 50
+
+# Install LDC
+FROM llvm_deps AS dlang_deps
+ARG D_VERSION=ldc-1.26.0
+ARG DPATH=/dlang
+RUN set -ex \
+  && mkdir ${DPATH} \
+  && curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH} \
+  && chmod 755 -R ${DPATH} \
+  && ln -s ${DPATH}/${D_VERSION} ${DPATH}/dc \
+  && ls ${DPATH}
+ENV PATH="${DPATH}/${D_VERSION}/bin:${PATH}"
+ENV LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="${DPATH}/${D_VERSION}/lib:${LD_LIBRARY_PATH}"
+
+FROM dlang_deps AS build_tools_deps
+ARG CMAKE_VERSION=3.20.3
+RUN set -ex \
+  # GCC (for vcpkg install)
+  && apt-get install -y --no-install-recommends build-essential \
+  # CMake
+  && wget -O cmake-${CMAKE_VERSION}-Linux-x86_64.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+  && sh cmake-${CMAKE_VERSION}-Linux-x86_64.sh -- --skip-license --prefix=/usr \
+  && rm -f cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+  # vcpkg
+  && git clone --depth=1 https://github.com/microsoft/vcpkg \
+  && ./vcpkg/bootstrap-vcpkg.sh -useSystemBinaries
+
+FROM dlang_deps AS remote_dev_ssh_deps
+RUN ( \
+  echo 'LogLevel DEBUG2'; \
+  echo 'PermitRootLogin yes'; \
+  echo 'PasswordAuthentication yes'; \
+  echo 'Subsystem sftp /usr/lib/openssh/sftp-server'; \
+  ) > /etc/ssh/sshd_config_test_clion \
+  && mkdir /run/sshd
+RUN useradd -m user \
+  && yes password | passwd user
+RUN usermod -s /bin/bash user
+CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_test_clion"]

--- a/Dockerfile.local-dev
+++ b/Dockerfile.local-dev
@@ -2,12 +2,12 @@
 # Remote development container for VS Code and CLion
 # 
 # Build and run:
-#   docker build -t gentool-devcontainer -f Dockerfile.clion-remote .
+#   docker build -t gentool-devcontainer -f Dockerfile.local-dev .
 #   docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name gentool-devcontainer
 #   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
 #
 # stop:
-#   docker stop clion_remote_env
+#   docker stop gentool-devcontainer
 # 
 # ssh credentials (test user):
 #   user@password


### PR DESCRIPTION
Adds support for developing and building/running Ohmygentool from within your browser.
Lets put a link on the repo README and let anyone who is interested in contributing do so with a click? 😃 
- (No more "Set up C++ build tools, install LLVM..." yadda yadda)
- (I have a part 2 of this PR  coming which is a `devcontainer` Dockerfile for VS Code + CLion that have the required toolchain so you can just spin that up locally and you're g2g)

I have put this up at:
https://gitpod.io/#https://github.com/GavinRay97/Ohmygentool

If you visit that link and sign in with Github, it should pop you into a browser shell that has everything you need to develop + build OMG, except for Rapidjson (which isn't added as a submodule for some reason). You get 50 free dev hours per account per month.

To build:
```ps1
git clone https://github.com/Tencent/rapidjson.git deps/rapidjson
cp -r deps/rapidjson/include/rapidjson include
mkdir build
cd build
cmake .. -G Ninja
cmake ./-config Release
./gentool # Should show helptext
```

One note about the Dockerfile -- I download and unpack a static distribution of LLVM12, and then immediately afterwards I install `clang` and `lld` with `apt`.

This is because trying to build with CMake (even if passing `-DLLVM_DIR` and `-DClang_DIR`) always gave me this:
```ps1
CMake Error at /usr/lib/llvm-13/lib/cmake/clang/ClangTargets.cmake:699 (message):
  The imported target "clangBasic" references the file
     "/usr/lib/llvm-13/lib/libclangBasic.a"

Call Stack (most recent call first):
  /usr/lib/cmake/clang-13/ClangConfig.cmake:20 (include)
  CMakeLists.txt:7 (find_package)
```

Couldn't find a way around it trying to use this version 13.

And then the prebuilt LLVM binaries have some bug with `libc`, but they fix the CMake problem by adding a directory to `/usr/lib/cmake/clang`:

```ps1
gitpod /workspace/ohmygentool $ clang --version
clang: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by clang)
clang: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by clang)
```

So you wind up with the mess I have, but it works. Would be awesome if someone knew a fix to this.

**See bottom of screen output for OMG being compiled and then invoked:**

![image](https://user-images.githubusercontent.com/26604994/120741631-5a71b400-c4c3-11eb-8d8a-67d14506affa.png)